### PR TITLE
update templates from css-mashlib

### DIFF
--- a/templates/pod/wac/.acl.hbs
+++ b/templates/pod/wac/.acl.hbs
@@ -15,8 +15,6 @@
 <#owner>
     a acl:Authorization;
     acl:agent <{{webId}}>;
-    # Optional owner email, to be used for account recovery:
-    {{#if email}}acl:agent <mailto:{{{email}}}>;{{/if}}
     # Set the access to the root storage folder itself
     acl:accessTo <./>;
     # All resources will inherit this authorization, by default

--- a/templates/pod/wac/inbox/.acl.hbs
+++ b/templates/pod/wac/inbox/.acl.hbs
@@ -1,17 +1,19 @@
-@prefix : <#>.
-@prefix acl: <http://www.w3.org/ns/auth/acl#>.
-@prefix inbox: <./>.
-@prefix c: <../profile/card#>.
+# ACL resource for the profile Inbox
 
-:Append
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<#owner>
     a acl:Authorization;
-    acl:accessTo inbox:;
-    acl:agentClass acl:AuthenticatedAgent;
-    acl:default inbox:;
-    acl:mode acl:Append.
-:ControlReadWrite
-    a acl:Authorization;
-    acl:accessTo inbox:;
     acl:agent <{{webId}}>;
-    acl:default inbox:;
-    acl:mode acl:Control, acl:Read, acl:Write.
+    acl:accessTo <./>;
+    acl:default <./>;
+    acl:mode
+        acl:Read, acl:Write, acl:Control.
+
+# Appendable by authenticated, but NOT public-readable
+<#authenticated>
+    a acl:Authorization;
+    acl:agentClass acl:AuthenticatedAgent;
+    acl:accessTo <./>;
+    acl:mode acl:Append.

--- a/templates/pod/wac/profile/.acl.hbs
+++ b/templates/pod/wac/profile/.acl.hbs
@@ -1,18 +1,16 @@
 @prefix : <#>.
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
-@prefix pro: <./>.
-@prefix c: <card#>.
 
 :ControlReadWrite
     a acl:Authorization;
-    acl:accessTo pro:;
-    {{#if email}}acl:agent c:me, <mailto:{{email}}>;{{/if}}
-    acl:default pro:;
+    acl:accessTo <./>;
+    acl:agent <{{webId}}>;
+    acl:default <./>;
     acl:mode acl:Control, acl:Read, acl:Write.
 :Read
     a acl:Authorization;
-    acl:accessTo pro:;
+    acl:accessTo <./>;
     acl:agentClass foaf:Agent;
-    acl:default pro:;
+    acl:default <./>;
     acl:mode acl:Read.

--- a/templates/pod/wac/profile/card$.ttl.hbs
+++ b/templates/pod/wac/profile/card$.ttl.hbs
@@ -9,10 +9,10 @@
 
 <{{webId}}>
     {{#if name}}foaf:name "{{name}}";{{/if}}
-    space:storage <{{podBaseUrl}}>;
-    ldp:inbox <{{podBaseUrl}}inbox/>;
-    space:preferencesFile <{{podBaseUrl}}/settings/prefs.ttl>;
-    solid:privateTypeIndex <{{podBaseUrl}}/settings/privateTypeIndex.ttl>;
-    solid:publicTypeIndex <{{podBaseUrl}}/settings/publicTypeIndex.ttl>;
+    space:storage <../>;
+    ldp:inbox <../inbox/>;
+    space:preferencesFile <../settings/prefs.ttl>;
+    solid:privateTypeIndex <../settings/privateTypeIndex.ttl>;
+    solid:publicTypeIndex <../settings/publicTypeIndex.ttl>;
     {{#if oidcIssuer}}solid:oidcIssuer <{{oidcIssuer}}>;{{/if}}
     a foaf:Person.

--- a/templates/pod/wac/settings/publicTypeIndex.ttl.acl.hbs
+++ b/templates/pod/wac/settings/publicTypeIndex.ttl.acl.hbs
@@ -1,4 +1,3 @@
-# ACL resource for the WebID profile document
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 


### PR DESCRIPTION
templates has been updated mainly for `card$.ttl.hbs` to replace `{{podBaseUrl}}` that did not exist by `..`
This solution works for `subdomain` and `suffix`.