### PR TITLE
Disable slash-redirecting code

### DIFF
--- a/config/prod.json
+++ b/config/prod.json
@@ -24,7 +24,7 @@
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
-    "pivot:config/storage/backend/file.json",
+    "css:config/storage/backend/file.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/pod.json",
     "css:config/storage/middleware/default.json",


### PR DESCRIPTION
Due to #29 I'm disabling the code from #19 and using the upstream code.

This means that #4 is now fully unsupported again (both for public and for non-public resources)