### PR TITLE
Make homepage HTML valid and proofread Acceptable Use

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1,65 +1,102 @@
 <!DOCTYPE html>
-<!-- saved from url=(0044)/.account/oidc/consent/ -->
-<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>An application is requesting access</title>
-  <link rel="stylesheet" href="/.well-known/css/styles/main.css?v=7" type="text/css">
-  <script type="text/javascript" src="/.well-known/css/scripts/util.js?v=7"></script>
-</head>
-<body>
-  <header>
-    <a href="/"><img src="/.well-known/css/images/solid.svg" alt="[Solid logo]"></a>
-    <h1>Pivot</h1>
-  </header>
-  <main>
-    <h1>Welcome to this Solid Server</h1>
+  <link rel="stylesheet" href="https://solidcommunity.net/.well-known/css/styles/main.css?v=7" type="text/css">
+  <script src="/.well-known/css/scripts/util.js?v=7"></script>
+  <style>
+    .actions a {
+      font-weight: 600;
+      cursor: pointer;
+      padding: .5em 2em;
+      border: 0px;
+      background-color: #7c4dff;
+      color: white;
+      text-decoration: none;
+    }
 
-    <p class="actions">
-      <a href="/.account/login/password/register/"><button id="register" type="submit">Register</button></a>
-      <a href="/.account/login/password/"><button id="login" type="submit">Login</button></a>
-    </p>
-  <h2>Acceptable use policy</h2>
-    <p>
-      This system is intended for developers and early adopters to try out the Solid platform as we continue to develop and refine it. 
-      solidcommunity.net is run by a loose collection of volunteers. We reserve the right to change or modify this policy at any time.    
-    </p>
-    <p>
-      To use this system, you must understand that we cannot make any guarantees regarding the security and privacy of data that you may store in a solidcommunity.net Solid pod, or concerning the system's functionality and availability.
-    </p>
-    <p>
-      Consequently, Solid Pods on Solidcommunity.net must not be used to store personal data, or any data that is otherwise sensitive, private, confidential, or intended in any way for commercial use.    
-    </p>
-    <p>
-      When you use Solid, information is stored in your Solid pod and the Solid pods of other users, depending on the actions you take and the apps you use. You and other Solid pod users control who has access to that information. Some information, like your solid profile, is public.
-    </p>
-    <p>
-      As a user of solidcommunity.net, you have the responsibility to understand what data you are storing in your Pod, with whom that data is shared, and what, if any, data you have made public.
-    </p>
-    <p>
-      If you add public information to Solid, then you must expect this information to be visible to anyone. You must ensure that such data is appropriate, as set out below, and also suitable for the legal jurisdictions and cultural communities in which you are connected. Information shared with a limited set of people must also be written responsibly and read discerningly.
-    </p>
-    <p>
-      By using solidcommunity.net, you agree not to misuse the system or to assist or enable anyone else to misuse the system. For example, you must not do, or attempt to do, any of the following in connection with solidcommunity.net services:
-    <br/>
+    .actions a:hover {
+      background-color: #18a9e6;
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <header>
+      <a href="/"><img src="/.well-known/css/images/solid.svg" alt="[Solid logo]"></a>
+      <h1>Pivot</h1>
+    </header>
+    <main>
+      <h1>Welcome to this Solid Server</h1>
+      <p class="actions">
+        <a href="/.account/login/password/register/">Register</a>
+        <a href="/.account/login/password/">Login</a>
+      </p>
+      <h2>Acceptable use policy</h2>
+      <p>
+        This system is intended for developers and early adopters to try out the Solid platform as we continue to
+        develop
+        and refine it.
+        solidcommunity.net is run by a loose collection of volunteers. We reserve the right to change or modify this
+        policy at any time.
+      </p>
+      <p>
+        To use this system, you must understand that we cannot make any guarantees regarding the security and privacy of
+        data that you may store in a solidcommunity.net Solid pod, or concerning the system's functionality and
+        availability.
+      </p>
+      <p>
+        Consequently, Solid Pods on Solidcommunity.net must not be used to store personal data, or any data that is
+        otherwise sensitive, private, confidential, or intended in any way for commercial use.
+      </p>
+      <p>
+        When you use Solid, information is stored in your Solid pod and the Solid pods of other users, depending on the
+        actions you take and the apps you use. You and other Solid pod users control who has access to that information.
+        Some information, like your solid profile, is public.
+      </p>
+      <p>
+        As a user of solidcommunity.net, you have the responsibility to understand what data you are storing in your
+        Pod,
+        with whom that data is shared, and what, if any, data you have made public.
+      </p>
+      <p>
+        If you add public information to Solid, then you must expect this information to be visible to anyone. You must
+        ensure that such data is appropriate, as set out below, and also suitable for the legal jurisdictions and
+        cultural
+        communities in which you are connected. Information shared with a limited set of people must also be written
+        responsibly and read discerningly.
+      </p>
+      <p>
+        By using solidcommunity.net, you agree not to misuse the system or to assist or enable anyone else to misuse the
+        system. For example, you must not do, or attempt to do, any of the following in connection with
+        solidcommunity.net
+        services:
+      </p>
       <ul>
         <li>
-          violate the law in any way, including by storing, publishing or sharing illegal material, including material that's fraudulent, defamatory, or misleading;
+          violate the law in any way, including by storing, publishing or sharing illegal material, including material
+          that's fraudulent, defamatory, or misleading;
         </li>
         <li>
-          breach or otherwise circumvent any security or authentication measures;        
+          breach or otherwise circumvent any security or authentication measures;
         </li>
         <li>
-          interfere with or disrupt any user, host, or network, for example by sending a virus, overloading, flooding, spamming, or mail-bombing any part of solidcommunity.net;
+          interfere with or disrupt any user, host, or network, for example by sending a virus, overloading, flooding,
+          spamming, or mail-bombing any part of solidcommunity.net;
         </li>
         <li>
-          access, search, or create accounts for solidcommunity.net by any means other than our publicly supported interfaces (for example, by "scraping" or creating accounts in bulk);
+          access, search, or create accounts for solidcommunity.net by any means other than our publicly supported
+          interfaces (for example, by "scraping" or creating accounts in bulk);
         </li>
         <li>
-          send unsolicited communications, promotions or advertisements, or spam;        
+          send unsolicited communications, promotions or advertisements, or spam;
         </li>
         <li>
-          send altered, deceptive or false source-identifying information, including "spoofing" or "phishing";        
+          send altered, deceptive or false source-identifying information, including "spoofing" or "phishing";
         </li>
         <li>
           promote or advertise products or services other than your own without appropriate authorisation;
@@ -68,31 +105,29 @@
           abuse referrals or promotions to get more storage space than deserved;
         </li>
         <li>
-          violate the privacy or infringe the rights of others;        
+          violate the privacy or infringe the rights of others;
         </li>
         <li>
-          Use solidcommunity.net to violate any law or regulation.        
+          Use solidcommunity.net to violate any law or regulation.
         </li>
         <li>
           Store personal data, IE, any information relating to an identified or identifiable natural person.
         </li>
-        
       </ul>
-    </p>
-    <p>
-      If any user abuses or misuses the system, assists anyone else to abuse or misuse the system, or monopolises an unfair proportion of available system or network resources, we reserve the right to limit that user’s activity or close and delete that user’s account. Such acts may also give rise to civil or criminal consequences.    
-    </p>
-    
-  </main>
-  <footer>
-    <p>
-      Powered by <a href="https://github.com/solid-contrib/pivot">Pivot</a>
-      thanks to <a href="https://github.com/CommunitySolidServer/CommunitySolidServer">CSS</a>
-      and the <a href="https://solidproject.org/">Solid Community</a>
-    </p>
-  </footer>
-
-
-
-
-</body></html>
+      <p>
+        If any user abuses or misuses the system, assists anyone else to abuse or misuse the system, or monopolises an
+        unfair proportion of available system or network resources, we reserve the right to limit that user’s activity
+        or
+        close and delete that user’s account. Such acts may also give rise to civil or criminal consequences.
+      </p>
+    </main>
+    <footer>
+      <p>
+        Powered by <a href="https://github.com/solid-contrib/pivot">Pivot</a>
+        thanks to <a href="https://github.com/CommunitySolidServer/CommunitySolidServer">CSS</a>
+        and the <a href="https://solidproject.org/">Solid Community</a>
+      </p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/www/index.html
+++ b/www/index.html
@@ -38,59 +38,38 @@
       </p>
       <h2>Acceptable use policy</h2>
       <p>
-        This system is intended for developers and early adopters to try out the Solid platform as we continue to
-        develop
-        and refine it.
-        solidcommunity.net is run by a loose collection of volunteers. We reserve the right to change or modify this
-        policy at any time.
+        This system is intended for developers and early adopters to try out the Solid platform as we continue to develop and refine it. We reserve the right to change or modify this policy at any time.
       </p>
       <p>
-        To use this system, you must understand that we cannot make any guarantees regarding the security and privacy of
-        data that you may store in a solidcommunity.net Solid pod, or concerning the system's functionality and
-        availability.
+        To use this system, you must understand that we cannot make any guarantees regarding the security and privacy of data that you may store in a solidcommunity.net Solid pod, or concerning the system's functionality and availability.
       </p>
       <p>
-        Consequently, Solid Pods on Solidcommunity.net must not be used to store personal data, or any data that is
-        otherwise sensitive, private, confidential, or intended in any way for commercial use.
+        Consequently, Solid Pods on Solidcommunity.net must not be used to store personal data, or any data that is otherwise sensitive, private, confidential, or intended in any way for commercial use.
       </p>
       <p>
-        When you use Solid, information is stored in your Solid pod and the Solid pods of other users, depending on the
-        actions you take and the apps you use. You and other Solid pod users control who has access to that information.
-        Some information, like your solid profile, is public.
+        When you use Solid, information is stored in your Solid pod and the Solid pods of other users, depending on the actions you take and the apps you use. You and other Solid pod users control who has access to that information. Some information, like your Solid profile, is public.
       </p>
       <p>
-        As a user of solidcommunity.net, you have the responsibility to understand what data you are storing in your
-        Pod,
-        with whom that data is shared, and what, if any, data you have made public.
+        As a user of solidcommunity.net, you have the responsibility to understand what data you are storing in your Pod, with whom that data is shared, and what, if any, data you have made public.
       </p>
       <p>
-        If you add public information to Solid, then you must expect this information to be visible to anyone. You must
-        ensure that such data is appropriate, as set out below, and also suitable for the legal jurisdictions and
-        cultural
-        communities in which you are connected. Information shared with a limited set of people must also be written
-        responsibly and read discerningly.
+        If you add public information to Solid, then you must expect this information to be visible to anyone. You must ensure that such data is appropriate, as set out below, and also suitable for the legal jurisdictions and cultural communities in which you are connected. Information shared with a limited set of people must also be written responsibly and read discerningly.
       </p>
       <p>
-        By using solidcommunity.net, you agree not to misuse the system or to assist or enable anyone else to misuse the
-        system. For example, you must not do, or attempt to do, any of the following in connection with
-        solidcommunity.net
-        services:
+        By using solidcommunity.net, you agree not to misuse the system or to assist or enable anyone else to misuse the system. For example, you must not do, or attempt to do, any of the following in connection with solidcommunity.net services:
       </p>
       <ul>
         <li>
-          violate the law in any way, including by storing, publishing or sharing illegal material, including material
-          that's fraudulent, defamatory, or misleading;
+          violate the law in any way, including by storing, publishing or sharing illegal material, including material that's fraudulent, defamatory, or misleading;
         </li>
         <li>
           breach or otherwise circumvent any security or authentication measures;
         </li>
         <li>
-          interfere with or disrupt any user, host, or network, for example by sending a virus, overloading, flooding,
-          spamming, or mail-bombing any part of solidcommunity.net;
+          interfere with or disrupt any user, host, or network, for example by sending a virus, overloading, flooding, spamming, or mail-bombing any part of solidcommunity.net;
         </li>
         <li>
-          access, search, or create accounts for solidcommunity.net by any means other than our publicly supported
-          interfaces (for example, by "scraping" or creating accounts in bulk);
+          access, search, or create accounts for solidcommunity.net by any means other than our publicly supported interfaces (for example, by "scraping" or creating accounts in bulk);
         </li>
         <li>
           send unsolicited communications, promotions or advertisements, or spam;
@@ -115,17 +94,12 @@
         </li>
       </ul>
       <p>
-        If any user abuses or misuses the system, assists anyone else to abuse or misuse the system, or monopolises an
-        unfair proportion of available system or network resources, we reserve the right to limit that user’s activity
-        or
-        close and delete that user’s account. Such acts may also give rise to civil or criminal consequences.
+        If any user abuses or misuses the system, assists anyone else to abuse or misuse the system, or monopolises an unfair proportion of available system or network resources, we reserve the right to limit that user’s activity or close and delete that user’s account. Such acts may also give rise to civil or criminal consequences.
       </p>
     </main>
     <footer>
       <p>
-        Powered by <a href="https://github.com/solid-contrib/pivot">Pivot</a>
-        thanks to <a href="https://github.com/CommunitySolidServer/CommunitySolidServer">CSS</a>
-        and the <a href="https://solidproject.org/">Solid Community</a>
+        Powered by <a href="https://github.com/solid-contrib/pivot">Pivot</a> thanks to <a href="https://github.com/CommunitySolidServer/CommunitySolidServer">CSS</a> and the <a href="https://solidproject.org/">Solid Community</a>.
       </p>
     </footer>
   </div>


### PR DESCRIPTION
This PR fixes several markup errors in the homepage's HTML markup ([first commit](https://github.com/solid-contrib/pivot/commit/66b44cec810be38b447bc22c7366d61c5a074c19); see screenshot).

It also ammends the text of the Acceptable Use Policy (removing the sentence "solidcommunity.net is run by a loose collection of volunteers" in the [second commit](https://github.com/solid-contrib/pivot/commit/823d9c4c326b03348a7fb5b0e734331c69f14c9c)).
